### PR TITLE
Check simple SimpleRegistry before DynamicRegistry

### DIFF
--- a/PayumBuilder.php
+++ b/PayumBuilder.php
@@ -527,7 +527,7 @@ class PayumBuilder
             $dynamicRegistry = new DynamicRegistry($this->gatewayConfigStorage, $registry);
             $dynamicRegistry->setBackwardCompatibility(false);
 
-            $registry = new FallbackRegistry($dynamicRegistry, $registry);
+            $registry = new FallbackRegistry($registry, $dynamicRegistry);
         }
 
         if ($this->mainRegistry) {


### PR DESCRIPTION
Should have opened an issue for discussion first since I think I am solving an edge case for myself.

I wanted any configured gateways to take precedence over any dynamic one.

What I really wanted was to override certain variables from my dynamic gateway, but still haven't found a good way to do that.