### PR TITLE
Allow league/uri ^7.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
         "php-http/message": "^1.0",
         "php-http/client-implementation": "^1.0",
         "psr/log": "^1 || ^2 || ^3",
-        "league/uri": "^6.4",
-        "league/uri-components": "^2.2",
+        "league/uri": "^6.4 || ^7.0",
+        "league/uri-components": "^2.2 || ^7.0",
         "twig/twig": "^1.34|^2.4|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
This complements the already existing commit (https://github.com/Payum/Core/commit/41692d36993e53a0274d603476c228904a9d78ba) that supports v7.x