### PR TITLE
Refactor RequestTokenVerifier to address League/Uri deprecations

### DIFF
--- a/Security/Util/RequestTokenVerifier.php
+++ b/Security/Util/RequestTokenVerifier.php
@@ -3,7 +3,7 @@
 namespace Payum\Core\Security\Util;
 
 use League\Uri\Components\Path;
-use League\Uri\Http;
+use League\Uri\Http as HttpUri;
 
 class RequestTokenVerifier
 {
@@ -14,11 +14,20 @@ class RequestTokenVerifier
      */
     public static function isValid($requestUri, $tokenUri)
     {
-        $uri = Http::createFromString($requestUri);
-        $altUri = Http::createFromString($tokenUri);
+        $uri = method_exists(HttpUri::class, 'new') ? HttpUri::new($requestUri) : HttpUri::createFromString(
+                $requestUri
+            );
+        $altUri = method_exists(HttpUri::class, 'new') ? HttpUri::new($tokenUri) : HttpUri::createFromString(
+                $tokenUri
+            );
+        
 
-        $uriPath = Path::createFromUri($uri);
-        $altUriPath = Path::createFromUri($altUri);
+        $uriPath = method_exists(Path::class, 'new') ? Path::new($uri) : Path::createFromUri(
+                $uri
+            );
+        $altUriPath = method_exists(Path::class, 'new') ? Path::new($altUri) : Path::createFromUri(
+                $altUri
+        );
 
         return rawurldecode((string) $uriPath) === rawurldecode((string) $altUriPath);
     }


### PR DESCRIPTION
This change is a follow-up to maintain consistency with similar refactors already merged in other parts of the Core package.

This commit updates RequestTokenVerifier.php to ensure compatibility with newer versions of the league/uri library while maintaining backward compatibility.

Following the pattern established in previous core updates (commit 4efe88d), the following changes were made:
- Replaced deprecated static factory calls with the new new() method where available.
- Added method_exists checks for both HttpUri and Path classes to prevent breaking changes in environments using older versions of the library.
- Aligned imports and class aliases with existing core standards (using HttpUri as an alias for League\Uri\Http).

These changes eliminate deprecation notices in modern PHP environments and unify the URI handling logic across the project.